### PR TITLE
Add dashboard screen

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,0 +1,12 @@
+import Dashboard from './components/Dashboard.js';
+
+/**
+ * Application entry point. Renders the Dashboard component.
+ * @module App
+ */
+function main() {
+  const root = document.getElementById('root');
+  root.replaceChildren(Dashboard());
+}
+
+window.addEventListener('DOMContentLoaded', main);

--- a/frontend/components/Dashboard.js
+++ b/frontend/components/Dashboard.js
@@ -1,0 +1,31 @@
+import LineChart from './LineChart.js';
+import { getMonthlyExpenses, getMonthlyIncome, getTagSpendings } from '../data/sampleData.js';
+import NavBar from './NavBar.js';
+
+/**
+ * Dashboard screen rendering three line charts and navigation buttons.
+ * @module Dashboard
+ */
+export default function Dashboard() {
+  const root = document.createElement('div');
+  root.appendChild(NavBar());
+
+  const expenseCanvas = document.createElement('canvas');
+  const incomeCanvas = document.createElement('canvas');
+  const tagCanvas = document.createElement('canvas');
+  root.appendChild(expenseCanvas);
+  root.appendChild(incomeCanvas);
+  root.appendChild(tagCanvas);
+
+  const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+  new LineChart(expenseCanvas, months, getMonthlyExpenses(), '支出', 'rgba(255, 99, 132, 1)');
+  new LineChart(incomeCanvas, months, getMonthlyIncome(), '収入', 'rgba(54, 162, 235, 1)');
+
+  const tagData = getTagSpendings();
+  tagData.forEach((d, index) => {
+    new LineChart(tagCanvas, months, d.amounts, d.tag, `hsl(${index * 60}, 70%, 50%)`);
+  });
+
+  return root;
+}

--- a/frontend/components/LineChart.js
+++ b/frontend/components/LineChart.js
@@ -1,0 +1,38 @@
+/**
+ * LineChart component for rendering line charts using Chart.js.
+ * @module LineChart
+ */
+
+export default class LineChart {
+  /**
+   * Creates a chart instance.
+   * @param {HTMLCanvasElement} canvas - Canvas element for rendering chart
+   * @param {string[]} labels - Labels for the x-axis
+   * @param {number[]} data - Data points for the chart
+   * @param {string} label - Dataset label
+   * @param {string} color - Line color
+   */
+  constructor(canvas, labels, data, label, color) {
+    this.chart = new Chart(canvas.getContext('2d'), {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [{
+          label,
+          data,
+          borderColor: color,
+          backgroundColor: color,
+          fill: false
+        }]
+      },
+      options: {
+        responsive: true,
+        scales: {
+          y: {
+            beginAtZero: true
+          }
+        }
+      }
+    });
+  }
+}

--- a/frontend/components/NavBar.js
+++ b/frontend/components/NavBar.js
@@ -1,0 +1,21 @@
+/**
+ * Navigation bar component with links to registration pages.
+ * @module NavBar
+ */
+
+export default function NavBar() {
+  const container = document.createElement('div');
+  container.className = 'nav-bar';
+
+  const expenseLink = document.createElement('a');
+  expenseLink.href = '#expense';
+  expenseLink.textContent = '支出登録';
+  container.appendChild(expenseLink);
+
+  const incomeLink = document.createElement('a');
+  incomeLink.href = '#income';
+  incomeLink.textContent = '収入登録';
+  container.appendChild(incomeLink);
+
+  return container;
+}

--- a/frontend/data/sampleData.js
+++ b/frontend/data/sampleData.js
@@ -1,0 +1,32 @@
+/**
+ * @module sampleData
+ * Provides sample datasets for line charts in the dashboard.
+ */
+
+/**
+ * Returns monthly expense amounts for 12 months.
+ * @returns {number[]} Monthly expense data
+ */
+export function getMonthlyExpenses() {
+  return [50000, 48000, 52000, 51000, 53000, 55000, 54000, 56000, 58000, 60000, 59000, 61000];
+}
+
+/**
+ * Returns monthly income amounts for 12 months.
+ * @returns {number[]} Monthly income data
+ */
+export function getMonthlyIncome() {
+  return [300000, 300000, 300000, 300000, 320000, 300000, 300000, 300000, 300000, 330000, 300000, 300000];
+}
+
+/**
+ * Returns tag-based spending amounts for 12 months.
+ * @returns {Object<string, number[]>[]} Tag-based monthly expense data
+ */
+export function getTagSpendings() {
+  return [
+    { tag: 'Food', amounts: [15000, 14000, 16000, 15500, 16500, 17000, 16800, 17200, 17500, 18000, 17800, 18500] },
+    { tag: 'Rent', amounts: [20000, 20000, 20000, 20000, 20000, 20000, 20000, 20000, 20000, 20000, 20000, 20000] },
+    { tag: 'Entertainment', amounts: [5000, 6000, 4000, 4500, 5500, 5000, 6500, 6000, 5500, 7000, 6500, 6000] }
+  ];
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>Dashboard</title>
+  <style>
+    .nav-bar { margin-bottom: 10px; }
+    .nav-bar a { margin-right: 10px; }
+    canvas { max-width: 600px; margin-bottom: 20px; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script type="module" src="./App.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "household_account",
+  "version": "1.0.0",
+  "description": "家計簿アプリ開発",
+  "main": "server.js",
+  "scripts": {
+    "test": "node tests/data.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,39 @@
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Serves static files from the frontend directory.
+ * @module server
+ */
+
+const frontendDir = path.join(__dirname, 'frontend');
+const port = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  let filePath = path.join(frontendDir, req.url === '/' ? 'index.html' : req.url);
+  if (!filePath.startsWith(frontendDir)) {
+    res.statusCode = 400;
+    res.end('Bad Request');
+    return;
+  }
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.statusCode = 404;
+      res.end('Not Found');
+      return;
+    }
+    const ext = path.extname(filePath);
+    const map = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css' };
+    res.setHeader('Content-Type', map[ext] || 'text/plain');
+    res.end(data);
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Server running on http://localhost:${port}`);
+});

--- a/tests/data.test.js
+++ b/tests/data.test.js
@@ -1,0 +1,15 @@
+import assert from 'assert';
+import { getMonthlyExpenses, getMonthlyIncome, getTagSpendings } from '../frontend/data/sampleData.js';
+
+/**
+ * Simple tests for sample data generation functions.
+ */
+function run() {
+  assert.strictEqual(getMonthlyExpenses().length, 12, 'Expenses should have 12 entries');
+  assert.strictEqual(getMonthlyIncome().length, 12, 'Income should have 12 entries');
+  const tags = getTagSpendings();
+  assert.ok(Array.isArray(tags) && tags.length > 0, 'Tag data should be non-empty');
+  console.log('All tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- set up Node project with ES modules
- add server to serve dashboard page
- implement dashboard UI with Chart.js graphs
- include sample dataset and basic tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d6a043ff4832ab8fb8c849442eec2