### PR TITLE
Add SQLite db layer and tests

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,0 +1,70 @@
+import Database from 'better-sqlite3';
+import path from 'path';
+
+/**
+ * Database utilities for managing expenses and incomes.
+ * @module db
+ */
+
+const dbPath = process.env.DB_FILE || path.join(process.cwd(), 'data.sqlite');
+
+/**
+ * SQLite database instance.
+ * @type {import('better-sqlite3').Database}
+ */
+export const db = new Database(dbPath);
+
+db.exec(`
+CREATE TABLE IF NOT EXISTS expenses (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  amount INTEGER NOT NULL,
+  description TEXT,
+  created_at INTEGER DEFAULT (strftime('%s','now'))
+);
+CREATE TABLE IF NOT EXISTS incomes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  amount INTEGER NOT NULL,
+  description TEXT,
+  created_at INTEGER DEFAULT (strftime('%s','now'))
+);
+`);
+
+/**
+ * Inserts an expense record.
+ * @param {number} amount - Expense amount.
+ * @param {string} [description] - Optional description.
+ * @returns {number} Inserted row ID.
+ */
+export function addExpense(amount, description = '') {
+  const stmt = db.prepare('INSERT INTO expenses (amount, description) VALUES (?, ?)');
+  const info = stmt.run(amount, description);
+  return Number(info.lastInsertRowid);
+}
+
+/**
+ * Retrieves all expenses.
+ * @returns {object[]} List of expense rows.
+ */
+export function getExpenses() {
+  return db.prepare('SELECT * FROM expenses').all();
+}
+
+/**
+ * Inserts an income record.
+ * @param {number} amount - Income amount.
+ * @param {string} [description] - Optional description.
+ * @returns {number} Inserted row ID.
+ */
+export function addIncome(amount, description = '') {
+  const stmt = db.prepare('INSERT INTO incomes (amount, description) VALUES (?, ?)');
+  const info = stmt.run(amount, description);
+  return Number(info.lastInsertRowid);
+}
+
+/**
+ * Retrieves all incomes.
+ * @returns {object[]} List of income rows.
+ */
+export function getIncomes() {
+  return db.prepare('SELECT * FROM incomes').all();
+}

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "description": "家計簿アプリ開発",
   "main": "server.js",
   "scripts": {
-    "test": "node tests/data.test.js"
+    "test": "node tests/data.test.js && node tests/db.test.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "better-sqlite3": "^9.0.0"
+  }
 }

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ import http from 'http';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { addExpense, getExpenses, addIncome, getIncomes } from './db.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -15,6 +16,42 @@ const frontendDir = path.join(__dirname, 'frontend');
 const port = process.env.PORT || 3000;
 
 const server = http.createServer((req, res) => {
+  if (req.url === '/expenses' && req.method === 'GET') {
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(getExpenses()));
+    return;
+  }
+
+  if (req.url === '/incomes' && req.method === 'GET') {
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(getIncomes()));
+    return;
+  }
+
+  if (req.url === '/expenses' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      const data = JSON.parse(body || '{}');
+      addExpense(Number(data.amount), data.description || '');
+      res.statusCode = 201;
+      res.end('OK');
+    });
+    return;
+  }
+
+  if (req.url === '/incomes' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      const data = JSON.parse(body || '{}');
+      addIncome(Number(data.amount), data.description || '');
+      res.statusCode = 201;
+      res.end('OK');
+    });
+    return;
+  }
+
   let filePath = path.join(frontendDir, req.url === '/' ? 'index.html' : req.url);
   if (!filePath.startsWith(frontendDir)) {
     res.statusCode = 400;

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpFile = path.join(os.tmpdir(), `dbtest-${Date.now()}.sqlite`);
+process.env.DB_FILE = tmpFile;
+
+const dbModule = await import('../db.js');
+
+dbModule.addExpense(1000, 'coffee');
+const expenses = dbModule.getExpenses();
+assert.strictEqual(expenses.length, 1, 'One expense should be stored');
+
+dbModule.addIncome(2000, 'salary');
+const incomes = dbModule.getIncomes();
+assert.strictEqual(incomes.length, 1, 'One income should be stored');
+
+fs.unlinkSync(tmpFile);
+console.log('SQLite tests passed');


### PR DESCRIPTION
## Summary
- install `better-sqlite3` and update test script
- implement lightweight SQLite utilities in `db.js`
- expose HTTP endpoints in `server.js` for expenses and incomes
- add tests covering SQLite operations

## Testing
- `npm test` *(fails: Cannot find package 'better-sqlite3' due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_685e53895938832a923f2d446cc88b23