### PR TITLE
Fix duplicate Chart.js instance error

### DIFF
--- a/frontend/components/LineChart.js
+++ b/frontend/components/LineChart.js
@@ -6,13 +6,20 @@
 export default class LineChart {
   /**
    * Creates a chart instance.
-   * @param {HTMLCanvasElement} canvas - Canvas element for rendering chart
-   * @param {string[]} labels - Labels for the x-axis
-   * @param {number[]} data - Data points for the chart
-   * @param {string} label - Dataset label
-   * @param {string} color - Line color
-   */
+  * @param {HTMLCanvasElement} canvas - Canvas element for rendering chart
+  * @param {string[]} labels - Labels for the x-axis
+  * @param {number[]} data - Data points for the chart
+  * @param {string} label - Dataset label
+  * @param {string} color - Line color
+  * Existing charts on the same canvas are destroyed to avoid Chart.js errors.
+  */
   constructor(canvas, labels, data, label, color) {
+    if (typeof Chart !== 'undefined' && typeof Chart.getChart === 'function') {
+      const existing = Chart.getChart(canvas);
+      if (existing) {
+        existing.destroy();
+      }
+    }
     this.chart = new Chart(canvas.getContext('2d'), {
       type: 'line',
       data: {


### PR DESCRIPTION
## Summary
- avoid Chart.js canvas reuse errors by destroying existing charts before creating a new one

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f5cd96b14832ab7ec36e7436374e8