### PR TITLE
Add recent records view with Tailwind styling

### DIFF
--- a/frontend/components/Dashboard.js
+++ b/frontend/components/Dashboard.js
@@ -1,5 +1,5 @@
 import LineChart from './LineChart.js';
-import { getMonthlyExpenses, getMonthlyIncome, getTagSpendings } from '../data/sampleData.js';
+import { getMonthlyExpenses, getMonthlyIncome, getTagSpendings, getRecentRecords } from '../data/sampleData.js';
 import NavBar from './NavBar.js';
 
 /**
@@ -13,14 +13,21 @@ import NavBar from './NavBar.js';
  */
 export default async function Dashboard() {
   const root = document.createElement('div');
+  root.className = 'min-h-screen flex flex-col items-center p-4 bg-gray-50';
   root.appendChild(NavBar());
 
   const expenseCanvas = document.createElement('canvas');
+  expenseCanvas.className = 'w-full h-64';
   const incomeCanvas = document.createElement('canvas');
+  incomeCanvas.className = 'w-full h-64';
   const tagCanvas = document.createElement('canvas');
-  root.appendChild(expenseCanvas);
-  root.appendChild(incomeCanvas);
-  root.appendChild(tagCanvas);
+  tagCanvas.className = 'w-full h-64';
+  const chartContainer = document.createElement('div');
+  chartContainer.className = 'w-full max-w-3xl grid grid-cols-1 gap-4';
+  chartContainer.appendChild(expenseCanvas);
+  chartContainer.appendChild(incomeCanvas);
+  chartContainer.appendChild(tagCanvas);
+  root.appendChild(chartContainer);
 
   const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
 
@@ -36,6 +43,32 @@ export default async function Dashboard() {
   tagData.forEach((d, index) => {
     new LineChart(tagCanvas, months, d.amounts, d.tag, `hsl(${index * 60}, 70%, 50%)`);
   });
+
+  const recent = await getRecentRecords();
+  const listContainer = document.createElement('div');
+  listContainer.className = 'w-full max-w-3xl grid grid-cols-1 md:grid-cols-2 gap-4 mt-6';
+
+  const expTable = document.createElement('table');
+  expTable.className = 'min-w-full text-sm text-left border';
+  expTable.innerHTML = '<caption class="font-bold">最近6ヶ月の支出</caption><thead><tr><th class="border px-2">日付</th><th class="border px-2">内容</th><th class="border px-2">金額</th></tr></thead><tbody></tbody>';
+  recent.expenses.forEach((e) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td class="border px-2">${new Date(e.created_at * 1000).toLocaleDateString()}</td><td class="border px-2">${e.description || ''}</td><td class="border px-2 text-right">${e.amount}</td>`;
+    expTable.querySelector('tbody').appendChild(tr);
+  });
+
+  const incTable = document.createElement('table');
+  incTable.className = 'min-w-full text-sm text-left border';
+  incTable.innerHTML = '<caption class="font-bold">最近6ヶ月の収入</caption><thead><tr><th class="border px-2">日付</th><th class="border px-2">内容</th><th class="border px-2">金額</th></tr></thead><tbody></tbody>';
+  recent.incomes.forEach((i) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td class="border px-2">${new Date(i.created_at * 1000).toLocaleDateString()}</td><td class="border px-2">${i.description || ''}</td><td class="border px-2 text-right">${i.amount}</td>`;
+    incTable.querySelector('tbody').appendChild(tr);
+  });
+
+  listContainer.appendChild(expTable);
+  listContainer.appendChild(incTable);
+  root.appendChild(listContainer);
 
   return root;
 }

--- a/frontend/components/ExpenseForm.js
+++ b/frontend/components/ExpenseForm.js
@@ -4,19 +4,24 @@
  */
 export default function ExpenseForm() {
   const container = document.createElement('div');
+  container.className = 'min-h-screen flex flex-col items-center p-4 bg-gray-50';
 
   const form = document.createElement('form');
+  form.className = 'flex flex-col space-y-2 w-full max-w-sm';
   const amountInput = document.createElement('input');
   amountInput.type = 'number';
   amountInput.placeholder = '金額';
+  amountInput.className = 'border p-2';
 
   const descInput = document.createElement('input');
   descInput.type = 'text';
   descInput.placeholder = '内容';
+  descInput.className = 'border p-2';
 
   const submitBtn = document.createElement('button');
   submitBtn.type = 'submit';
   submitBtn.textContent = '登録';
+  submitBtn.className = 'bg-blue-600 text-white p-2';
 
   form.appendChild(amountInput);
   form.appendChild(descInput);
@@ -40,6 +45,7 @@ export default function ExpenseForm() {
   const backLink = document.createElement('a');
   backLink.href = '#';
   backLink.textContent = '戻る';
+  backLink.className = 'text-blue-600 underline mt-4';
   container.appendChild(backLink);
 
   return container;

--- a/frontend/components/IncomeForm.js
+++ b/frontend/components/IncomeForm.js
@@ -4,19 +4,24 @@
  */
 export default function IncomeForm() {
   const container = document.createElement('div');
+  container.className = 'min-h-screen flex flex-col items-center p-4 bg-gray-50';
 
   const form = document.createElement('form');
+  form.className = 'flex flex-col space-y-2 w-full max-w-sm';
   const amountInput = document.createElement('input');
   amountInput.type = 'number';
   amountInput.placeholder = '金額';
+  amountInput.className = 'border p-2';
 
   const descInput = document.createElement('input');
   descInput.type = 'text';
   descInput.placeholder = '内容';
+  descInput.className = 'border p-2';
 
   const submitBtn = document.createElement('button');
   submitBtn.type = 'submit';
   submitBtn.textContent = '登録';
+  submitBtn.className = 'bg-blue-600 text-white p-2';
 
   form.appendChild(amountInput);
   form.appendChild(descInput);
@@ -40,6 +45,7 @@ export default function IncomeForm() {
   const backLink = document.createElement('a');
   backLink.href = '#';
   backLink.textContent = '戻る';
+  backLink.className = 'text-blue-600 underline mt-4';
   container.appendChild(backLink);
 
   return container;

--- a/frontend/components/NavBar.js
+++ b/frontend/components/NavBar.js
@@ -5,21 +5,24 @@
 
 export default function NavBar() {
   const container = document.createElement('div');
-  container.className = 'nav-bar';
+  container.className = 'flex space-x-4 mb-4';
 
   const homeLink = document.createElement('a');
   homeLink.href = '#';
   homeLink.textContent = 'ダッシュボード';
+  homeLink.className = 'text-blue-600 underline';
   container.appendChild(homeLink);
 
   const expenseLink = document.createElement('a');
   expenseLink.href = '#expense';
   expenseLink.textContent = '支出登録';
+  expenseLink.className = 'text-blue-600 underline';
   container.appendChild(expenseLink);
 
   const incomeLink = document.createElement('a');
   incomeLink.href = '#income';
   incomeLink.textContent = '収入登録';
+  incomeLink.className = 'text-blue-600 underline';
   container.appendChild(incomeLink);
 
   return container;

--- a/frontend/data/sampleData.js
+++ b/frontend/data/sampleData.js
@@ -57,3 +57,25 @@ export async function getTagSpendings() {
   });
   return Object.entries(tagMap).map(([tag, amounts]) => ({ tag, amounts }));
 }
+
+/**
+ * Fetch expense and income records for the last six months.
+ * @returns {Promise<{expenses: object[], incomes: object[]}>} Recent records
+ */
+export async function getRecentRecords() {
+  const [expRes, incRes] = await Promise.all([
+    fetch('/expenses'),
+    fetch('/incomes')
+  ]);
+  const [expenses, incomes] = await Promise.all([
+    expRes.json(),
+    incRes.json()
+  ]);
+  const cutoff = new Date();
+  cutoff.setMonth(cutoff.getMonth() - 5);
+  cutoff.setDate(1);
+  const cutoffTs = Math.floor(cutoff.getTime() / 1000);
+  const recentExpenses = expenses.filter((e) => e.created_at >= cutoffTs);
+  const recentIncomes = incomes.filter((i) => i.created_at >= cutoffTs);
+  return { expenses: recentExpenses, incomes: recentIncomes };
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,11 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Dashboard</title>
-  <style>
-    .nav-bar { margin-bottom: 10px; }
-    .nav-bar a { margin-right: 10px; }
-    canvas { max-width: 600px; margin-bottom: 20px; }
-  </style>
+  <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
   <div id="root"></div>

--- a/tests/data.test.js
+++ b/tests/data.test.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { getMonthlyExpenses, getMonthlyIncome, getTagSpendings } from '../frontend/data/sampleData.js';
+import { getMonthlyExpenses, getMonthlyIncome, getTagSpendings, getRecentRecords } from '../frontend/data/sampleData.js';
 
 /**
  * Simple tests for data retrieval functions using mocked fetch.
@@ -34,6 +34,10 @@ async function run() {
 
   const tags = await getTagSpendings();
   assert.ok(Array.isArray(tags) && tags.length === 2, 'Tag data should contain two tags');
+
+  const recent = await getRecentRecords();
+  assert.ok(Array.isArray(recent.expenses), 'Recent expenses should be an array');
+  assert.ok(Array.isArray(recent.incomes), 'Recent incomes should be an array');
 
   console.log('All tests passed');
 }


### PR DESCRIPTION
## Summary
- integrate Tailwind via CDN
- add recent six month records API helper
- display recent expenses and incomes in Dashboard
- style pages using Tailwind
- update tests for new helper

## Testing
- `npm test` *(fails: Cannot find package 'better-sqlite3')*

------
https://chatgpt.com/codex/tasks/task_e_685f603ad460832abb4e4429c06e81f2