### PR TITLE
Add monthly expense listing and editing

### DIFF
--- a/db.js
+++ b/db.js
@@ -50,6 +50,18 @@ export function getExpenses() {
 }
 
 /**
+ * Updates an existing expense record.
+ * @param {number} id - Expense identifier.
+ * @param {number} amount - New amount value.
+ * @param {string} description - Updated description text.
+ * @returns {void}
+ */
+export function updateExpense(id, amount, description) {
+  const stmt = db.prepare('UPDATE expenses SET amount = ?, description = ? WHERE id = ?');
+  stmt.run(amount, description, id);
+}
+
+/**
  * Inserts an income record.
  * @param {number} amount - Income amount.
  * @param {string} [description] - Optional description.

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,6 +1,7 @@
 import Dashboard from './components/Dashboard.js';
 import ExpenseForm from './components/ExpenseForm.js';
 import IncomeForm from './components/IncomeForm.js';
+import ExpensesList from './components/ExpensesList.js';
 
 /**
  * Application entry point. Renders components based on location hash.
@@ -16,6 +17,8 @@ async function render() {
   const hash = window.location.hash;
   if (hash === '#expense') {
     root.replaceChildren(ExpenseForm());
+  } else if (hash === '#expenses') {
+    root.replaceChildren(await ExpensesList());
   } else if (hash === '#income') {
     root.replaceChildren(IncomeForm());
   } else {

--- a/frontend/components/ExpensesList.js
+++ b/frontend/components/ExpensesList.js
@@ -1,0 +1,61 @@
+/**
+ * ExpensesList component that displays expenses for a selected month and allows editing them.
+ * @module ExpensesList
+ */
+import NavBar from './NavBar.js';
+
+/**
+ * Create the expenses list page element.
+ * @returns {Promise<HTMLDivElement>} Root element containing the list
+ */
+export default async function ExpensesList() {
+  const container = document.createElement('div');
+  container.className = 'min-h-screen flex flex-col items-center p-4 bg-gray-50';
+  container.appendChild(NavBar());
+
+  const monthInput = document.createElement('input');
+  monthInput.type = 'month';
+  monthInput.className = 'border p-2';
+  const now = new Date();
+  monthInput.value = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  container.appendChild(monthInput);
+
+  const table = document.createElement('table');
+  table.className = 'min-w-full text-sm text-left border mt-4';
+  table.innerHTML = '<thead><tr><th class="border px-2">日付</th><th class="border px-2">内容</th><th class="border px-2">金額</th><th class="border px-2">保存</th></tr></thead><tbody></tbody>';
+  container.appendChild(table);
+
+  async function load() {
+    const res = await fetch('/expenses');
+    const data = await res.json();
+    const [y, m] = monthInput.value.split('-').map(Number);
+    const tbody = table.querySelector('tbody');
+    tbody.innerHTML = '';
+    data.filter((e) => {
+      const d = new Date(e.created_at * 1000);
+      return d.getFullYear() === y && d.getMonth() + 1 === m;
+    }).forEach((e) => {
+      const tr = document.createElement('tr');
+      const date = new Date(e.created_at * 1000).toLocaleDateString();
+      tr.innerHTML = `<td class="border px-2">${date}</td>` +
+        `<td class="border px-2"><input class="desc border p-1" type="text" value="${e.description || ''}"></td>` +
+        `<td class="border px-2"><input class="amount border p-1 text-right" type="number" value="${e.amount}"></td>` +
+        '<td class="border px-2"><button class="save bg-blue-600 text-white px-2">保存</button></td>';
+      tr.querySelector('.save').addEventListener('click', async () => {
+        const amount = Number(tr.querySelector('.amount').value);
+        const description = tr.querySelector('.desc').value;
+        await fetch(`/expenses/${e.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ amount, description })
+        });
+        await load();
+      });
+      tbody.appendChild(tr);
+    });
+  }
+
+  monthInput.addEventListener('change', load);
+  await load();
+  return container;
+}

--- a/frontend/components/NavBar.js
+++ b/frontend/components/NavBar.js
@@ -19,6 +19,12 @@ export default function NavBar() {
   expenseLink.className = 'text-blue-600 underline';
   container.appendChild(expenseLink);
 
+  const expenseListLink = document.createElement('a');
+  expenseListLink.href = '#expenses';
+  expenseListLink.textContent = '支出一覧';
+  expenseListLink.className = 'text-blue-600 underline';
+  container.appendChild(expenseListLink);
+
   const incomeLink = document.createElement('a');
   incomeLink.href = '#income';
   incomeLink.textContent = '収入登録';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "家計簿アプリ開発",
   "main": "server.js",
   "scripts": {
-    "test": "node tests/data.test.js && node tests/db.test.js && node tests/expenseForm.test.js"
+    "test": "node tests/data.test.js && node tests/db.test.js && node tests/expenseForm.test.js && node tests/expensesList.test.js"
   },
   "keywords": [],
   "author": "",

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ import http from 'http';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { addExpense, getExpenses, addIncome, getIncomes } from './db.js';
+import { addExpense, getExpenses, addIncome, getIncomes, updateExpense } from './db.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -35,6 +35,19 @@ const server = http.createServer((req, res) => {
       const data = JSON.parse(body || '{}');
       addExpense(Number(data.amount), data.description || '');
       res.statusCode = 201;
+      res.end('OK');
+    });
+    return;
+  }
+
+  if (req.url.startsWith('/expenses/') && req.method === 'PUT') {
+    const id = Number(req.url.split('/')[2]);
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      const data = JSON.parse(body || '{}');
+      updateExpense(id, Number(data.amount), data.description || '');
+      res.statusCode = 200;
       res.end('OK');
     });
     return;

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -12,6 +12,10 @@ dbModule.addExpense(1000, 'coffee');
 const expenses = dbModule.getExpenses();
 assert.strictEqual(expenses.length, 1, 'One expense should be stored');
 
+dbModule.updateExpense(expenses[0].id, 1500, 'tea');
+const updated = dbModule.getExpenses()[0];
+assert.strictEqual(updated.amount, 1500, 'Expense amount should be updated');
+
 dbModule.addIncome(2000, 'salary');
 const incomes = dbModule.getIncomes();
 assert.strictEqual(incomes.length, 1, 'One income should be stored');

--- a/tests/expensesList.test.js
+++ b/tests/expensesList.test.js
@@ -1,0 +1,40 @@
+import assert from 'assert';
+import { JSDOM } from 'jsdom';
+import ExpensesList from '../frontend/components/ExpensesList.js';
+
+/**
+ * Tests for the ExpensesList component.
+ */
+async function run() {
+  const records = [
+    { id: 1, amount: 100, description: 'A', created_at: Date.parse('2024-05-01') / 1000 },
+    { id: 2, amount: 200, description: 'B', created_at: Date.parse('2024-05-10') / 1000 },
+    { id: 3, amount: 300, description: 'C', created_at: Date.parse('2024-06-01') / 1000 }
+  ];
+  let putCalled = false;
+  global.fetch = async (url, opts) => {
+    if (url === '/expenses') return { json: async () => records };
+    if (url.startsWith('/expenses/') && opts && opts.method === 'PUT') { putCalled = true; return { ok: true }; }
+    throw new Error('unknown url');
+  };
+
+  const dom = new JSDOM('<!DOCTYPE html><body><div id="root"></div></body>', { url: 'http://localhost' });
+  global.document = dom.window.document;
+  global.window = dom.window;
+
+  const el = await ExpensesList();
+  dom.window.document.body.appendChild(el);
+  const monthInput = el.querySelector('input[type="month"]');
+  monthInput.value = '2024-05';
+  monthInput.dispatchEvent(new dom.window.Event('change'));
+  await new Promise(res => setImmediate(res));
+  const rows = el.querySelectorAll('tbody tr');
+  assert.strictEqual(rows.length, 2, 'Should show two records for selected month');
+
+  rows[0].querySelector('.save').dispatchEvent(new dom.window.Event('click'));
+  await new Promise(res => setImmediate(res));
+  assert.ok(putCalled, 'PUT should be called when saving');
+  console.log('ExpensesList tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- support updating expense data in database
- expose PUT `/expenses/:id` API in server
- create `ExpensesList` component to view and edit monthly expenses
- update navbar and router to link to the new list page
- test new database update logic and component behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f637471b0832a90f8bb20cf0cdbea