### PR TITLE
Add half-year lists and improve navbar

### DIFF
--- a/frontend/components/Dashboard.js
+++ b/frontend/components/Dashboard.js
@@ -14,7 +14,7 @@ import NavBar from './NavBar.js';
 export default async function Dashboard() {
   const root = document.createElement('div');
   root.className = 'min-h-screen flex flex-col items-center p-4 bg-gray-50';
-  root.appendChild(NavBar());
+  root.appendChild(NavBar('ダッシュボード'));
 
   const expenseCanvas = document.createElement('canvas');
   expenseCanvas.className = 'w-full h-64';
@@ -23,13 +23,31 @@ export default async function Dashboard() {
   const tagCanvas = document.createElement('canvas');
   tagCanvas.className = 'w-full h-64';
   const chartContainer = document.createElement('div');
-  chartContainer.className = 'w-full max-w-3xl grid grid-cols-1 gap-4';
+  chartContainer.className = 'grid grid-cols-1 gap-4';
   chartContainer.appendChild(expenseCanvas);
   chartContainer.appendChild(incomeCanvas);
   chartContainer.appendChild(tagCanvas);
-  root.appendChild(chartContainer);
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'w-full max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-4';
+  wrapper.appendChild(chartContainer);
 
   const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+  const halfYearContainer = document.createElement('div');
+  halfYearContainer.className = 'grid grid-cols-1 gap-4';
+
+  const createHalfTable = (title, start, expenses, income) => {
+    const table = document.createElement('table');
+    table.className = 'min-w-full text-sm text-left border';
+    table.innerHTML = `<caption class="font-bold">${title}</caption><thead><tr><th class="border px-2">月</th><th class="border px-2">支出</th><th class="border px-2">収入</th></tr></thead><tbody></tbody>`;
+    for (let i = start; i < start + 6; i++) {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td class="border px-2">${months[i]}</td><td class="border px-2 text-right">${expenses[i]}</td><td class="border px-2 text-right">${income[i]}</td>`;
+      table.querySelector('tbody').appendChild(tr);
+    }
+    return table;
+  };
 
   const [expenses, income, tagData] = await Promise.all([
     getMonthlyExpenses(),
@@ -43,6 +61,11 @@ export default async function Dashboard() {
   tagData.forEach((d, index) => {
     new LineChart(tagCanvas, months, d.amounts, d.tag, `hsl(${index * 60}, 70%, 50%)`);
   });
+
+  halfYearContainer.appendChild(createHalfTable('前半6ヶ月', 0, expenses, income));
+  halfYearContainer.appendChild(createHalfTable('後半6ヶ月', 6, expenses, income));
+  wrapper.appendChild(halfYearContainer);
+  root.appendChild(wrapper);
 
   const recent = await getRecentRecords();
   const listContainer = document.createElement('div');

--- a/frontend/components/ExpenseForm.js
+++ b/frontend/components/ExpenseForm.js
@@ -1,3 +1,5 @@
+import NavBar from './NavBar.js';
+
 /**
  * Expense page component providing registration and list editing in one screen.
  * The layout mirrors the income screen.
@@ -6,6 +8,7 @@
 export default function ExpenseForm() {
   const container = document.createElement('div');
   container.className = 'min-h-screen flex flex-col items-center p-4 bg-gray-50';
+  container.appendChild(NavBar('支出登録'));
 
   // Month selection controls
   const monthSelectContainer = document.createElement('div');
@@ -20,7 +23,9 @@ export default function ExpenseForm() {
   expenseListContainer.className = 'w-full max-w-sm mt-4';
   container.appendChild(expenseListContainer);
 
+  let renderSeq = 0;
   const renderExpenseList = async (year, month) => {
+    const seq = ++renderSeq;
     expenseListContainer.innerHTML = '';
     const res = await fetch('/expenses');
     const expenses = await res.json();
@@ -49,6 +54,7 @@ export default function ExpenseForm() {
       `;
       ul.appendChild(li);
     });
+    if (seq !== renderSeq) return;
     expenseListContainer.appendChild(ul);
 
     ul.querySelectorAll('.edit-btn').forEach((button) => {

--- a/frontend/components/IncomeForm.js
+++ b/frontend/components/IncomeForm.js
@@ -1,3 +1,5 @@
+import NavBar from './NavBar.js';
+
 /**
  * Income input form component for registering incomes via the backend API.
  * @module IncomeForm
@@ -5,6 +7,7 @@
 export default function IncomeForm() {
   const container = document.createElement('div');
   container.className = 'min-h-screen flex flex-col items-center p-4 bg-gray-50';
+  container.appendChild(NavBar('収入登録'));
 
   // Month selection
   const monthSelectContainer = document.createElement('div');

--- a/frontend/components/NavBar.js
+++ b/frontend/components/NavBar.js
@@ -1,30 +1,44 @@
 /**
- * Navigation bar component with links to registration pages.
+ * Navigation bar component displaying the current screen title and links.
  * @module NavBar
  */
 
-export default function NavBar() {
-  const container = document.createElement('div');
-  container.className = 'flex space-x-4 mb-4';
+/**
+ * Creates a styled navigation bar.
+ *
+ * @param {string} title - Title of the current screen.
+ * @returns {HTMLElement} Navigation element.
+ */
+export default function NavBar(title) {
+  const nav = document.createElement('nav');
+  nav.className = 'bg-white shadow flex items-center justify-between p-4 mb-4 w-full';
+
+  const heading = document.createElement('div');
+  heading.textContent = title;
+  heading.className = 'font-bold text-lg';
+  nav.appendChild(heading);
+
+  const linkContainer = document.createElement('div');
+  linkContainer.className = 'space-x-4';
 
   const homeLink = document.createElement('a');
   homeLink.href = '#';
   homeLink.textContent = 'ダッシュボード';
-  homeLink.className = 'text-blue-600 underline';
-  container.appendChild(homeLink);
+  homeLink.className = 'text-blue-600 hover:underline';
+  linkContainer.appendChild(homeLink);
 
   const expenseLink = document.createElement('a');
   expenseLink.href = '#expense';
   expenseLink.textContent = '支出登録';
-  expenseLink.className = 'text-blue-600 underline';
-  container.appendChild(expenseLink);
-
+  expenseLink.className = 'text-blue-600 hover:underline';
+  linkContainer.appendChild(expenseLink);
 
   const incomeLink = document.createElement('a');
   incomeLink.href = '#income';
   incomeLink.textContent = '収入登録';
-  incomeLink.className = 'text-blue-600 underline';
-  container.appendChild(incomeLink);
+  incomeLink.className = 'text-blue-600 hover:underline';
+  linkContainer.appendChild(incomeLink);
 
-  return container;
+  nav.appendChild(linkContainer);
+  return nav;
 }


### PR DESCRIPTION
## Summary
- show half-year tables beside charts on the dashboard
- enhance navbar with page titles and styled links
- embed navbar into income and expense forms
- prevent double renderings in ExpenseForm

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading 'dispatchEvent'))*

------
https://chatgpt.com/codex/tasks/task_e_685fee469c70832aa15b3e8b4cd13e3d