### PR TITLE
Implement yearly dashboard table

### DIFF
--- a/frontend/components/Dashboard.js
+++ b/frontend/components/Dashboard.js
@@ -53,18 +53,36 @@ export default async function Dashboard() {
   wrapper.className = 'w-full max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-4';
   wrapper.appendChild(chartContainer);
 
-  const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  const months = [
+    '1月','2月','3月','4月','5月','6月',
+    '7月','8月','9月','10月','11月','12月'
+  ];
 
-  const halfYearContainer = document.createElement('div');
-  halfYearContainer.className = 'grid grid-cols-1 gap-4';
+  const yearInput = document.createElement('input');
+  yearInput.type = 'month';
+  yearInput.className = 'border p-1 mb-2 self-end';
+  yearInput.value = `${new Date().getFullYear()}-01`;
 
-  const createHalfTable = (title, start, expenses, income) => {
+  const yearlyContainer = document.createElement('div');
+  yearlyContainer.className = 'grid grid-cols-1 gap-4';
+
+  /**
+   * Create a summary table for one year.
+   *
+   * @param {number} year - The target year.
+   * @param {number[]} expenses - Monthly expense amounts.
+   * @param {number[]} income - Monthly income amounts.
+   * @returns {HTMLTableElement} Rendered table element.
+   */
+  const createYearTable = (year, expenses, income) => {
     const table = document.createElement('table');
     table.className = 'min-w-full text-sm text-left border';
-    table.innerHTML = `<caption class="font-bold">${title}</caption><thead><tr><th class="border px-2">月</th><th class="border px-2">支出</th><th class="border px-2">収入</th></tr></thead><tbody></tbody>`;
-    for (let i = start; i < start + 6; i++) {
+    table.innerHTML = `<caption class="font-bold">${year}年</caption><thead><tr><th class="border px-2">月</th><th class="border px-2">収入</th><th class="border px-2">支出</th><th class="border px-2">損益</th></tr></thead><tbody></tbody>`;
+    for (let i = 0; i < 12; i++) {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td class="border px-2">${months[i]}</td><td class="border px-2 text-right">${formatAmount(expenses[i])}</td><td class="border px-2 text-right">${formatAmount(income[i])}</td>`;
+      const diff = income[i] - expenses[i];
+      const diffClass = diff < 0 ? ' text-red-600' : '';
+      tr.innerHTML = `<td class="border px-2">${months[i]}</td><td class="border px-2 text-right">${formatAmount(income[i])}</td><td class="border px-2 text-right">${formatAmount(expenses[i])}</td><td class="border px-2 text-right${diffClass}">${formatAmount(diff)}</td>`;
       table.querySelector('tbody').appendChild(tr);
     }
     return table;
@@ -109,9 +127,9 @@ export default async function Dashboard() {
     Number(scaleSelect.value)
   );
 
-  halfYearContainer.appendChild(createHalfTable('前半6ヶ月', 0, expenses, income));
-  halfYearContainer.appendChild(createHalfTable('後半6ヶ月', 6, expenses, income));
-  wrapper.appendChild(halfYearContainer);
+  yearlyContainer.appendChild(createYearTable(new Date().getFullYear(), expenses, income));
+  wrapper.appendChild(yearInput);
+  wrapper.appendChild(yearlyContainer);
   root.appendChild(wrapper);
 
   const recent = await getRecentRecords();
@@ -153,6 +171,17 @@ export default async function Dashboard() {
     const idx = Number(tagSelect.value);
     const d = tagData[idx];
     tagChart.updateData(months, d.amounts, d.tag);
+  });
+
+  // reload yearly summary when year is changed
+  yearInput.addEventListener('change', async () => {
+    const year = new Date(yearInput.value).getFullYear();
+    const [exp, inc] = await Promise.all([
+      getMonthlyExpenses(year),
+      getMonthlyIncome(year)
+    ]);
+    yearlyContainer.innerHTML = '';
+    yearlyContainer.appendChild(createYearTable(year, exp, inc));
   });
 
   return root;

--- a/frontend/data/sampleData.js
+++ b/frontend/data/sampleData.js
@@ -8,10 +8,18 @@
  * @param {Array<{amount:number,created_at:number}>} items - Records to aggregate
  * @returns {number[]} Amount totals per month index (0-11)
  */
-function groupByMonth(items) {
+/**
+ * Aggregate amounts for a given year by month.
+ *
+ * @param {Array<{amount:number,created_at:number}>} items - Records to aggregate.
+ * @param {number} year - Target year for aggregation.
+ * @returns {number[]} Amount totals per month index (0-11).
+ */
+function groupByMonth(items, year) {
   const result = Array(12).fill(0);
   items.forEach((it) => {
     const date = new Date(it.created_at * 1000);
+    if (date.getFullYear() !== year) return;
     const month = date.getMonth();
     result[month] += it.amount;
   });
@@ -22,36 +30,55 @@ function groupByMonth(items) {
  * Fetch monthly expense amounts from the backend.
  * @returns {Promise<number[]>} Monthly expense totals
  */
-export async function getMonthlyExpenses() {
+/**
+ * Fetch monthly expense amounts for a specific year.
+ *
+ * @param {number} [year=new Date().getFullYear()] - Target year.
+ * @returns {Promise<number[]>} Monthly expense totals.
+ */
+export async function getMonthlyExpenses(year = new Date().getFullYear()) {
   const res = await fetch('/expenses');
   const data = await res.json();
-  return groupByMonth(data);
+  return groupByMonth(data, year);
 }
 
 /**
  * Fetch monthly income amounts from the backend.
  * @returns {Promise<number[]>} Monthly income totals
  */
-export async function getMonthlyIncome() {
+/**
+ * Fetch monthly income amounts for a specific year.
+ *
+ * @param {number} [year=new Date().getFullYear()] - Target year.
+ * @returns {Promise<number[]>} Monthly income totals.
+ */
+export async function getMonthlyIncome(year = new Date().getFullYear()) {
   const res = await fetch('/incomes');
   const data = await res.json();
-  return groupByMonth(data);
+  return groupByMonth(data, year);
 }
 
 /**
  * Fetch expenses and calculate tag-based spending amounts.
  * @returns {Promise<Object<string, number[]>[]>} Tag-based monthly expense data
  */
-export async function getTagSpendings() {
+/**
+ * Fetch expenses and calculate tag-based spending amounts for a year.
+ *
+ * @param {number} [year=new Date().getFullYear()] - Target year.
+ * @returns {Promise<Object<string, number[]>[]>} Tag-based monthly expense data.
+ */
+export async function getTagSpendings(year = new Date().getFullYear()) {
   const res = await fetch('/expenses');
   const data = await res.json();
   const tagMap = {};
   data.forEach((it) => {
+    const date = new Date(it.created_at * 1000);
+    if (date.getFullYear() !== year) return;
     const tag = it.description || 'その他';
     if (!tagMap[tag]) {
       tagMap[tag] = Array(12).fill(0);
     }
-    const date = new Date(it.created_at * 1000);
     const month = date.getMonth();
     tagMap[tag][month] += it.amount;
   });

--- a/tests/data.test.js
+++ b/tests/data.test.js
@@ -23,16 +23,24 @@ async function run() {
     };
   };
 
-  const expenses = await getMonthlyExpenses();
+  const year = new Date(expenseData[0].created_at * 1000).getFullYear();
+
+  const expenses = await getMonthlyExpenses(year);
   assert.strictEqual(expenses.length, 12, 'Expenses array should have 12 months');
   assert.strictEqual(expenses[0], 100);
   assert.strictEqual(expenses[1], 200);
 
-  const incomes = await getMonthlyIncome();
+  const emptyExpenses = await getMonthlyExpenses(year - 1);
+  assert.ok(emptyExpenses.every(v => v === 0), 'Different year returns zeros');
+
+  const incomes = await getMonthlyIncome(year);
   assert.strictEqual(incomes[0], 300);
   assert.strictEqual(incomes[2], 200);
 
-  const tags = await getTagSpendings();
+  const emptyIncomes = await getMonthlyIncome(year - 1);
+  assert.ok(emptyIncomes.every(v => v === 0), 'Different year incomes are zero');
+
+  const tags = await getTagSpendings(year);
   assert.ok(Array.isArray(tags) && tags.length === 2, 'Tag data should contain two tags');
 
   const recent = await getRecentRecords();


### PR DESCRIPTION
## Summary
- add optional year parameter for monthly data functions
- display yearly summary table on dashboard with calendar input
- update data tests for year-based filtering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686936c80ee4832a86c71b1515678931