### PR TITLE
Add delete and target month features

### DIFF
--- a/db.js
+++ b/db.js
@@ -19,12 +19,14 @@ CREATE TABLE IF NOT EXISTS expenses (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   amount INTEGER NOT NULL,
   description TEXT,
+  target_month TEXT NOT NULL DEFAULT (strftime('%Y-%m','now')),
   created_at INTEGER DEFAULT (strftime('%s','now'))
 );
 CREATE TABLE IF NOT EXISTS incomes (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   amount INTEGER NOT NULL,
   description TEXT,
+  target_month TEXT NOT NULL DEFAULT (strftime('%Y-%m','now')),
   created_at INTEGER DEFAULT (strftime('%s','now'))
 );
 `);
@@ -35,9 +37,9 @@ CREATE TABLE IF NOT EXISTS incomes (
  * @param {string} [description] - Optional description.
  * @returns {number} Inserted row ID.
  */
-export function addExpense(amount, description = '') {
-  const stmt = db.prepare('INSERT INTO expenses (amount, description) VALUES (?, ?)');
-  const info = stmt.run(amount, description);
+export function addExpense(amount, description = '', targetMonth = new Date().toISOString().slice(0, 7)) {
+  const stmt = db.prepare('INSERT INTO expenses (amount, description, target_month) VALUES (?, ?, ?)');
+  const info = stmt.run(amount, description, targetMonth);
   return Number(info.lastInsertRowid);
 }
 
@@ -50,15 +52,25 @@ export function getExpenses() {
 }
 
 /**
+ * Deletes an expense record by ID.
+ * @param {number} id - Expense identifier to remove.
+ * @returns {void}
+ */
+export function deleteExpense(id) {
+  const stmt = db.prepare('DELETE FROM expenses WHERE id = ?');
+  stmt.run(id);
+}
+
+/**
  * Updates an existing expense record.
  * @param {number} id - Expense identifier.
  * @param {number} amount - New amount value.
  * @param {string} description - Updated description text.
  * @returns {void}
  */
-export function updateExpense(id, amount, description) {
-  const stmt = db.prepare('UPDATE expenses SET amount = ?, description = ? WHERE id = ?');
-  stmt.run(amount, description, id);
+export function updateExpense(id, amount, description, targetMonth) {
+  const stmt = db.prepare('UPDATE expenses SET amount = ?, description = ?, target_month = ? WHERE id = ?');
+  stmt.run(amount, description, targetMonth, id);
 }
 
 /**
@@ -67,9 +79,9 @@ export function updateExpense(id, amount, description) {
  * @param {string} [description] - Optional description.
  * @returns {number} Inserted row ID.
  */
-export function addIncome(amount, description = '') {
-  const stmt = db.prepare('INSERT INTO incomes (amount, description) VALUES (?, ?)');
-  const info = stmt.run(amount, description);
+export function addIncome(amount, description = '', targetMonth = new Date().toISOString().slice(0, 7)) {
+  const stmt = db.prepare('INSERT INTO incomes (amount, description, target_month) VALUES (?, ?, ?)');
+  const info = stmt.run(amount, description, targetMonth);
   return Number(info.lastInsertRowid);
 }
 
@@ -82,15 +94,24 @@ export function getIncomes() {
 }
 
 /**
+ * Deletes an income record by ID.
+ * @param {number} id - Income identifier to remove.
+ * @returns {void}
+ */
+export function deleteIncome(id) {
+  const stmt = db.prepare('DELETE FROM incomes WHERE id = ?');
+  stmt.run(id);
+}
+
+/**
  * Retrieves incomes for a specific month and year.
  * @param {number} year - The year.
  * @param {number} month - The month (1-12).
  * @returns {object[]} List of income rows for the specified month.
  */
 export function getIncomesByMonth(year, month) {
-  const startOfMonth = new Date(year, month - 1, 1).getTime() / 1000;
-  const endOfMonth = new Date(year, month, 0).getTime() / 1000;
-  return db.prepare('SELECT * FROM incomes WHERE created_at >= ? AND created_at <= ? ORDER BY created_at DESC').all(startOfMonth, endOfMonth);
+  const ym = `${year}-${String(month).padStart(2, '0')}`;
+  return db.prepare('SELECT * FROM incomes WHERE target_month = ? ORDER BY created_at DESC').all(ym);
 }
 
 /**
@@ -100,7 +121,7 @@ export function getIncomesByMonth(year, month) {
  * @param {string} description - The new description.
  * @returns {object} Run result information.
  */
-export function updateIncome(id, amount, description) {
-  const stmt = db.prepare('UPDATE incomes SET amount = ?, description = ? WHERE id = ?');
-  return stmt.run(amount, description, id);
+export function updateIncome(id, amount, description, targetMonth) {
+  const stmt = db.prepare('UPDATE incomes SET amount = ?, description = ?, target_month = ? WHERE id = ?');
+  return stmt.run(amount, description, targetMonth, id);
 }

--- a/frontend/components/ExpenseForm.js
+++ b/frontend/components/ExpenseForm.js
@@ -50,14 +50,10 @@ export default function ExpenseForm() {
   container.renderPromise = renderPromise;
   const renderExpenseList = async (ym) => {
     const seq = ++renderSeq;
-    const [year, month] = ym.split('-').map(Number);
     expenseListContainer.innerHTML = '';
     const res = await fetch('/expenses');
     const expenses = await res.json();
-    const filtered = expenses.filter((e) => {
-      const d = new Date(e.created_at * 1000);
-      return d.getFullYear() === Number(year) && d.getMonth() + 1 === Number(month);
-    });
+    const filtered = expenses.filter((e) => e.target_month === ym);
 
     if (filtered.length === 0) {
       expenseListContainer.textContent = 'この月には支出がありません。';
@@ -75,7 +71,8 @@ export default function ExpenseForm() {
           <p>内容: ${expense.description}</p>
           <p>日付: ${new Date(expense.created_at * 1000).toLocaleDateString()}</p>
         </div>
-        <button data-id="${expense.id}" data-amount="${expense.amount}" data-description="${expense.description}" class="edit-btn bg-yellow-500 text-white px-3 py-1 rounded">編集</button>
+        <button data-id="${expense.id}" data-amount="${expense.amount}" data-description="${expense.description}" data-month="${expense.target_month}" class="edit-btn bg-yellow-500 text-white px-3 py-1 rounded">編集</button>
+        <button data-id="${expense.id}" class="delete-btn bg-red-500 text-white px-3 py-1 rounded ml-2">削除</button>
       `;
       ul.appendChild(li);
     });
@@ -89,10 +86,12 @@ export default function ExpenseForm() {
         const currentAmount = e.target.dataset.amount;
         const currentDescription = e.target.dataset.description;
         const listItem = e.target.closest('li');
+        const currentMonth = e.target.dataset.month;
         listItem.innerHTML = `
           <div class="flex flex-col space-y-2 w-full">
             <input type="number" class="edit-amount border p-2" value="${currentAmount}">
             <input type="text" class="edit-description border p-2" value="${currentDescription}">
+            <input type="month" class="edit-month border p-2" value="${currentMonth}">
             <div class="flex space-x-2">
               <button data-id="${id}" class="save-btn bg-green-500 text-white px-3 py-1 rounded">保存</button>
               <button class="cancel-btn bg-gray-500 text-white px-3 py-1 rounded">キャンセル</button>
@@ -103,10 +102,11 @@ export default function ExpenseForm() {
         listItem.querySelector('.save-btn').addEventListener('click', async () => {
           const newAmount = listItem.querySelector('.edit-amount').value;
           const newDescription = listItem.querySelector('.edit-description').value;
+          const newMonth = listItem.querySelector('.edit-month').value;
           await fetch(`/expenses/${id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ amount: Number(newAmount), description: newDescription })
+            body: JSON.stringify({ amount: Number(newAmount), description: newDescription, targetMonth: newMonth })
           });
           renderExpenseList(monthInput.value);
         });
@@ -114,6 +114,15 @@ export default function ExpenseForm() {
         listItem.querySelector('.cancel-btn').addEventListener('click', () => {
           renderExpenseList(monthInput.value);
         });
+      });
+    });
+    ul.querySelectorAll('.delete-btn').forEach((button) => {
+      button.addEventListener('click', async (e) => {
+        const id = e.target.dataset.id;
+        if (window.confirm('削除してよろしいですか？')) {
+          await fetch(`/expenses/${id}`, { method: 'DELETE' });
+          renderExpenseList(monthInput.value);
+        }
       });
     });
   };
@@ -135,7 +144,7 @@ export default function ExpenseForm() {
     await fetch('/expenses', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ amount, description })
+      body: JSON.stringify({ amount, description, targetMonth: monthInput.value })
     });
     amountInput.value = '';
     descInput.value = '';

--- a/frontend/components/IncomeForm.js
+++ b/frontend/components/IncomeForm.js
@@ -69,7 +69,8 @@ export default function IncomeForm() {
           <p>内容: ${income.description}</p>
           <p>日付: ${new Date(income.created_at * 1000).toLocaleDateString()}</p>
         </div>
-        <button data-id="${income.id}" data-amount="${income.amount}" data-description="${income.description}" class="edit-btn bg-yellow-500 text-white px-3 py-1 rounded">編集</button>
+        <button data-id="${income.id}" data-amount="${income.amount}" data-description="${income.description}" data-month="${income.target_month}" class="edit-btn bg-yellow-500 text-white px-3 py-1 rounded">編集</button>
+        <button data-id="${income.id}" class="delete-btn bg-red-500 text-white px-3 py-1 rounded ml-2">削除</button>
       `;
       ul.appendChild(li);
     });
@@ -81,12 +82,14 @@ export default function IncomeForm() {
         const id = e.target.dataset.id;
         const currentAmount = e.target.dataset.amount;
         const currentDescription = e.target.dataset.description;
+        const currentMonth = e.target.dataset.month;
         
         const listItem = e.target.closest('li');
         listItem.innerHTML = `
           <div class="flex flex-col space-y-2 w-full">
             <input type="number" class="edit-amount border p-2" value="${currentAmount}">
             <input type="text" class="edit-description border p-2" value="${currentDescription}">
+            <input type="month" class="edit-month border p-2" value="${currentMonth}">
             <div class="flex space-x-2">
               <button data-id="${id}" class="save-btn bg-green-500 text-white px-3 py-1 rounded">保存</button>
               <button class="cancel-btn bg-gray-500 text-white px-3 py-1 rounded">キャンセル</button>
@@ -97,10 +100,11 @@ export default function IncomeForm() {
         listItem.querySelector('.save-btn').addEventListener('click', async (saveEvent) => {
           const newAmount = listItem.querySelector('.edit-amount').value;
           const newDescription = listItem.querySelector('.edit-description').value;
+          const newMonth = listItem.querySelector('.edit-month').value;
           await fetch(`/incomes/${id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ amount: Number(newAmount), description: newDescription })
+            body: JSON.stringify({ amount: Number(newAmount), description: newDescription, targetMonth: newMonth })
           });
           renderIncomeList(monthInput.value); // Re-render after save
         });
@@ -108,6 +112,15 @@ export default function IncomeForm() {
         listItem.querySelector('.cancel-btn').addEventListener('click', () => {
           renderIncomeList(monthInput.value); // Re-render to revert changes
         });
+      });
+    });
+    ul.querySelectorAll('.delete-btn').forEach(button => {
+      button.addEventListener('click', async (e) => {
+        const id = e.target.dataset.id;
+        if (window.confirm('削除してよろしいですか？')) {
+          await fetch(`/incomes/${id}`, { method: 'DELETE' });
+          renderIncomeList(monthInput.value);
+        }
       });
     });
   };
@@ -129,7 +142,7 @@ export default function IncomeForm() {
     await fetch('/incomes', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ amount, description })
+      body: JSON.stringify({ amount, description, targetMonth: monthInput.value })
     });
     amountInput.value = '';
     descInput.value = '';

--- a/frontend/data/sampleData.js
+++ b/frontend/data/sampleData.js
@@ -11,8 +11,8 @@
 function groupByMonth(items) {
   const result = Array(12).fill(0);
   items.forEach((it) => {
-    const date = new Date(it.created_at * 1000);
-    const month = date.getMonth();
+    const [y, m] = (it.target_month || new Date(it.created_at * 1000).toISOString().slice(0,7)).split('-').map(Number);
+    const month = m - 1;
     result[month] += it.amount;
   });
   return result;
@@ -51,8 +51,7 @@ export async function getTagSpendings() {
     if (!tagMap[tag]) {
       tagMap[tag] = Array(12).fill(0);
     }
-    const date = new Date(it.created_at * 1000);
-    const month = date.getMonth();
+    const month = Number((it.target_month || new Date(it.created_at * 1000).toISOString().slice(0, 7)).split('-')[1]) - 1;
     tagMap[tag][month] += it.amount;
   });
   return Object.entries(tagMap).map(([tag, amounts]) => ({ tag, amounts }));

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ import http from 'http';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { addExpense, getExpenses, addIncome, getIncomes, getIncomesByMonth, updateIncome, updateExpense } from './db.js';
+import { addExpense, getExpenses, addIncome, getIncomes, getIncomesByMonth, updateIncome, updateExpense, deleteExpense, deleteIncome } from './db.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,7 +33,7 @@ const server = http.createServer((req, res) => {
     req.on('data', chunk => { body += chunk; });
     req.on('end', () => {
       const data = JSON.parse(body || '{}');
-      addExpense(Number(data.amount), data.description || '');
+      addExpense(Number(data.amount), data.description || '', data.targetMonth);
       res.statusCode = 201;
       res.end('OK');
     });
@@ -46,10 +46,18 @@ const server = http.createServer((req, res) => {
     req.on('data', chunk => { body += chunk; });
     req.on('end', () => {
       const data = JSON.parse(body || '{}');
-      updateExpense(id, Number(data.amount), data.description || '');
+      updateExpense(id, Number(data.amount), data.description || '', data.targetMonth);
       res.statusCode = 200;
       res.end('OK');
     });
+    return;
+  }
+
+  if (req.url.startsWith('/expenses/') && req.method === 'DELETE') {
+    const id = Number(req.url.split('/')[2]);
+    deleteExpense(id);
+    res.statusCode = 204;
+    res.end();
     return;
   }
 
@@ -58,7 +66,7 @@ const server = http.createServer((req, res) => {
     req.on('data', chunk => { body += chunk; });
     req.on('end', () => {
       const data = JSON.parse(body || '{}');
-      addIncome(Number(data.amount), data.description || '');
+      addIncome(Number(data.amount), data.description || '', data.targetMonth);
       res.statusCode = 201;
       res.end('OK');
     });
@@ -87,7 +95,7 @@ const server = http.createServer((req, res) => {
     req.on('end', () => {
       const data = JSON.parse(body || '{}');
       if (!isNaN(id) && data.amount && data.description !== undefined) {
-        updateIncome(id, Number(data.amount), data.description);
+        updateIncome(id, Number(data.amount), data.description, data.targetMonth);
         res.statusCode = 200;
         res.end('OK');
       } else {
@@ -95,6 +103,14 @@ const server = http.createServer((req, res) => {
         res.end('Bad Request');
       }
     });
+    return;
+  }
+
+  if (req.url.startsWith('/incomes/') && req.method === 'DELETE') {
+    const id = parseInt(req.url.split('/')[2]);
+    deleteIncome(id);
+    res.statusCode = 204;
+    res.end();
     return;
   }
 

--- a/tests/data.test.js
+++ b/tests/data.test.js
@@ -6,12 +6,12 @@ import { getMonthlyExpenses, getMonthlyIncome, getTagSpendings, getRecentRecords
  */
 async function run() {
   const expenseData = [
-    { amount: 100, description: 'Food', created_at: 1705276800 },
-    { amount: 200, description: 'Rent', created_at: 1707523200 }
+    { amount: 100, description: 'Food', created_at: 1705276800, target_month: '2024-01' },
+    { amount: 200, description: 'Rent', created_at: 1707523200, target_month: '2024-02' }
   ];
   const incomeData = [
-    { amount: 300, description: 'salary', created_at: 1704412800 },
-    { amount: 200, description: 'bonus', created_at: 1710892800 }
+    { amount: 300, description: 'salary', created_at: 1704412800, target_month: '2024-01' },
+    { amount: 200, description: 'bonus', created_at: 1710892800, target_month: '2024-03' }
   ];
   global.fetch = async (url) => {
     return {

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -8,17 +8,27 @@ process.env.DB_FILE = tmpFile;
 
 const dbModule = await import('../db.js');
 
-dbModule.addExpense(1000, 'coffee');
+dbModule.addExpense(1000, 'coffee', '2024-01');
 const expenses = dbModule.getExpenses();
 assert.strictEqual(expenses.length, 1, 'One expense should be stored');
 
-dbModule.updateExpense(expenses[0].id, 1500, 'tea');
+dbModule.updateExpense(expenses[0].id, 1500, 'tea', '2024-02');
 const updated = dbModule.getExpenses()[0];
 assert.strictEqual(updated.amount, 1500, 'Expense amount should be updated');
 
-dbModule.addIncome(2000, 'salary');
+dbModule.deleteExpense(updated.id);
+assert.strictEqual(dbModule.getExpenses().length, 0, 'Expense should be deleted');
+
+dbModule.addIncome(2000, 'salary', '2024-01');
 const incomes = dbModule.getIncomes();
 assert.strictEqual(incomes.length, 1, 'One income should be stored');
+
+dbModule.updateIncome(incomes[0].id, 2500, 'salary', '2024-02');
+const incUpdated = dbModule.getIncomes()[0];
+assert.strictEqual(incUpdated.amount, 2500, 'Income amount should be updated');
+
+dbModule.deleteIncome(incUpdated.id);
+assert.strictEqual(dbModule.getIncomes().length, 0, 'Income should be deleted');
 
 fs.unlinkSync(tmpFile);
 console.log('SQLite tests passed');

--- a/tests/expenseForm.test.js
+++ b/tests/expenseForm.test.js
@@ -7,18 +7,20 @@ import ExpenseForm from '../frontend/components/ExpenseForm.js';
  */
 async function run() {
   const records = [
-    { id: 1, amount: 100, description: 'A', created_at: Date.parse('2024-05-01') / 1000 },
-    { id: 2, amount: 200, description: 'B', created_at: Date.parse('2024-05-10') / 1000 },
-    { id: 3, amount: 300, description: 'C', created_at: Date.parse('2024-06-01') / 1000 }
+    { id: 1, amount: 100, description: 'A', created_at: Date.parse('2024-05-01') / 1000, target_month: '2024-05' },
+    { id: 2, amount: 200, description: 'B', created_at: Date.parse('2024-05-10') / 1000, target_month: '2024-05' },
+    { id: 3, amount: 300, description: 'C', created_at: Date.parse('2024-06-01') / 1000, target_month: '2024-06' }
   ];
   let postCalled = false;
   let putCalled = false;
+  let deleteCalled = false;
   global.fetch = async (url, opts) => {
     if (url === '/expenses' && (!opts || opts.method === 'GET')) {
       return { json: async () => records };
     }
     if (url === '/expenses' && opts && opts.method === 'POST') { postCalled = true; return { ok: true }; }
     if (url.startsWith('/expenses/') && opts && opts.method === 'PUT') { putCalled = true; return { ok: true }; }
+    if (url.startsWith('/expenses/') && opts && opts.method === 'DELETE') { deleteCalled = true; return { ok: true }; }
     throw new Error('unknown url');
   };
 
@@ -53,6 +55,11 @@ async function run() {
   items[0].querySelector('.save-btn').dispatchEvent(new dom.window.Event('click'));
   await new Promise(res => setImmediate(res));
   assert.ok(putCalled, 'PUT should be called when saving edit');
+
+  global.window.confirm = () => true;
+  items[1].querySelector('.delete-btn').dispatchEvent(new dom.window.Event('click'));
+  await new Promise(res => setImmediate(res));
+  assert.ok(deleteCalled, 'DELETE should be called when deleting record');
 
   console.log('ExpenseForm tests passed');
 }


### PR DESCRIPTION
## Summary
- enable target_month column in DB with CRUD helpers
- add delete endpoints and target month handling in server
- support editing target month and deletion in ExpenseForm and IncomeForm
- aggregate frontend data based on target month
- update unit tests for new functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68693930e3a8832a9787e1c9ca47a3c8