### PR TITLE
Refactor dashboard helpers

### DIFF
--- a/frontend/components/Dashboard.js
+++ b/frontend/components/Dashboard.js
@@ -1,7 +1,8 @@
-import LineChart from './LineChart.js';
 import { getMonthlyExpenses, getMonthlyIncome, getTagSpendings, getRecentRecords } from '../data/sampleData.js';
 import NavBar from './NavBar.js';
 import { formatAmount } from '../utils/format.js';
+import { createRangeTable } from '../utils/table.js';
+import { createIncomeChart, createExpenseChart, createTagChart } from '../utils/chartSetup.js';
 
 /**
  * Dashboard screen rendering three line charts and navigation buttons.
@@ -67,36 +68,6 @@ export default async function Dashboard() {
   const yearlyContainer = document.createElement('div');
   yearlyContainer.className = 'grid grid-cols-1 gap-4';
 
-  /**
-   * Create a summary table for a 12 month range ending at the given year-month.
-   *
-   * @param {number} year - End year.
-   * @param {number} month - End month (1-12).
-   * @param {Object<number, number[]>} expensesMap - Expense totals by year.
-   * @param {Object<number, number[]>} incomeMap - Income totals by year.
-   * @returns {HTMLTableElement} Rendered table element.
-   */
-  const createRangeTable = (year, month, expensesMap, incomeMap) => {
-    const start = new Date(year, month - 12);
-    const caption = `${start.getFullYear()}/${String(start.getMonth() + 1).padStart(2, '0')}〜${year}/${String(month).padStart(2, '0')}`;
-    const table = document.createElement('table');
-    table.className = 'min-w-full text-sm text-left border';
-    table.innerHTML = `<caption class="font-bold">${caption}</caption><thead><tr><th class="border px-2">年月</th><th class="border px-2">収入</th><th class="border px-2">支出</th><th class="border px-2">損益</th></tr></thead><tbody></tbody>`;
-    for (let i = 0; i < 12; i++) {
-      const d = new Date(year, month - 1 - i);
-      const y = d.getFullYear();
-      const m = d.getMonth();
-      const exp = (expensesMap[y] || [])[m] || 0;
-      const inc = (incomeMap[y] || [])[m] || 0;
-      const diff = inc - exp;
-      const diffClass = diff < 0 ? ' text-red-600' : '';
-      const ym = `${y}/${String(m + 1).padStart(2, '0')}`;
-      const tr = document.createElement('tr');
-      tr.innerHTML = `<td class="border px-2">${ym}</td><td class="border px-2 text-right">${formatAmount(inc)}</td><td class="border px-2 text-right">${formatAmount(exp)}</td><td class="border px-2 text-right${diffClass}">${formatAmount(diff)}</td>`;
-      table.querySelector('tbody').appendChild(tr);
-    }
-    return table;
-  };
 
   const [expenses, income, tagData] = await Promise.all([
     getMonthlyExpenses(),
@@ -104,20 +75,16 @@ export default async function Dashboard() {
     getTagSpendings()
   ]);
 
-  const incomeChart = new LineChart(
+  const incomeChart = createIncomeChart(
     incomeCanvas,
     months,
     income,
-    '収入',
-    'rgba(54, 162, 235, 1)',
     Number(scaleSelect.value)
   );
-  const expenseChart = new LineChart(
+  const expenseChart = createExpenseChart(
     expenseCanvas,
     months,
     expenses,
-    '支出',
-    'rgba(255, 99, 132, 1)',
     Number(scaleSelect.value)
   );
 
@@ -128,12 +95,11 @@ export default async function Dashboard() {
     tagSelect.appendChild(option);
   });
 
-  const tagChart = new LineChart(
+  const tagChart = createTagChart(
     tagCanvas,
     months,
     tagData[0]?.amounts || [],
     tagData[0]?.tag || '',
-    'rgba(75, 192, 192, 1)',
     Number(scaleSelect.value)
   );
 

--- a/frontend/utils/chartSetup.js
+++ b/frontend/utils/chartSetup.js
@@ -1,0 +1,46 @@
+import LineChart from '../components/LineChart.js';
+
+/**
+ * Factory functions for initializing common charts.
+ * @module chartSetup
+ */
+
+/**
+ * Create a line chart representing income values.
+ *
+ * @param {HTMLCanvasElement} canvas - Target canvas element.
+ * @param {string[]} labels - Labels for the x-axis.
+ * @param {number[]} data - Income amounts.
+ * @param {number} max - Maximum y-axis value.
+ * @returns {LineChart} Initialized chart instance.
+ */
+export function createIncomeChart(canvas, labels, data, max) {
+  return new LineChart(canvas, labels, data, '収入', 'rgba(54, 162, 235, 1)', max);
+}
+
+/**
+ * Create a line chart representing expense values.
+ *
+ * @param {HTMLCanvasElement} canvas - Target canvas element.
+ * @param {string[]} labels - Labels for the x-axis.
+ * @param {number[]} data - Expense amounts.
+ * @param {number} max - Maximum y-axis value.
+ * @returns {LineChart} Initialized chart instance.
+ */
+export function createExpenseChart(canvas, labels, data, max) {
+  return new LineChart(canvas, labels, data, '支出', 'rgba(255, 99, 132, 1)', max);
+}
+
+/**
+ * Create a line chart representing tag-based expenses.
+ *
+ * @param {HTMLCanvasElement} canvas - Target canvas element.
+ * @param {string[]} labels - Labels for the x-axis.
+ * @param {number[]} data - Expense amounts for the tag.
+ * @param {string} tag - Tag label.
+ * @param {number} max - Maximum y-axis value.
+ * @returns {LineChart} Initialized chart instance.
+ */
+export function createTagChart(canvas, labels, data, tag, max) {
+  return new LineChart(canvas, labels, data, tag, 'rgba(75, 192, 192, 1)', max);
+}

--- a/frontend/utils/table.js
+++ b/frontend/utils/table.js
@@ -1,0 +1,37 @@
+import { formatAmount } from "./format.js";
+
+/**
+ * Utility functions for creating table elements.
+ * @module table
+ */
+
+/**
+ * Create a summary table for a 12 month range ending at the given year-month.
+ *
+ * @param {number} year - End year.
+ * @param {number} month - End month (1-12).
+ * @param {Object<number, number[]>} expensesMap - Expense totals by year.
+ * @param {Object<number, number[]>} incomeMap - Income totals by year.
+ * @returns {HTMLTableElement} Rendered table element.
+ */
+export function createRangeTable(year, month, expensesMap, incomeMap) {
+  const start = new Date(year, month - 12);
+  const caption = `${start.getFullYear()}/${String(start.getMonth() + 1).padStart(2, '0')}〜${year}/${String(month).padStart(2, '0')}`;
+  const table = document.createElement('table');
+  table.className = 'min-w-full text-sm text-left border';
+  table.innerHTML = `<caption class="font-bold">${caption}</caption><thead><tr><th class="border px-2">年月</th><th class="border px-2">収入</th><th class="border px-2">支出</th><th class="border px-2">損益</th></tr></thead><tbody></tbody>`;
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(year, month - 1 - i);
+    const y = d.getFullYear();
+    const m = d.getMonth();
+    const exp = (expensesMap[y] || [])[m] || 0;
+    const inc = (incomeMap[y] || [])[m] || 0;
+    const diff = inc - exp;
+    const diffClass = diff < 0 ? ' text-red-600' : '';
+    const ym = `${y}/${String(m + 1).padStart(2, '0')}`;
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td class="border px-2">${ym}</td><td class="border px-2 text-right">${formatAmount(inc)}</td><td class="border px-2 text-right">${formatAmount(exp)}</td><td class="border px-2 text-right${diffClass}">${formatAmount(diff)}</td>`;
+    table.querySelector('tbody').appendChild(tr);
+  }
+  return table;
+}


### PR DESCRIPTION
## Summary
- extract `createRangeTable` to a new util module
- add chart factory helpers for better encapsulation
- update `Dashboard` to use the new utilities

## Testing
- `npm install` *(fails: cannot fetch packages)*
- `npm test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68724377d108832a8cf3c7e5c0517ab1