### PR TITLE
Implement cash management screen

### DIFF
--- a/db.js
+++ b/db.js
@@ -29,6 +29,16 @@ CREATE TABLE IF NOT EXISTS incomes (
   target_month TEXT NOT NULL DEFAULT (strftime('%Y-%m','now')),
   created_at INTEGER DEFAULT (strftime('%s','now'))
 );
+CREATE TABLE IF NOT EXISTS cash_starts (
+  month TEXT PRIMARY KEY,
+  amount INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS cash_withdrawals (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  month TEXT NOT NULL,
+  amount INTEGER NOT NULL,
+  created_at INTEGER DEFAULT (strftime('%s','now'))
+);
 `);
 
 /**
@@ -125,3 +135,60 @@ export function updateIncome(id, amount, description, targetMonth) {
   const stmt = db.prepare('UPDATE incomes SET amount = ?, description = ?, target_month = ? WHERE id = ?');
   return stmt.run(amount, description, targetMonth, id);
 }
+
+/**
+ * Get previous month string for YYYY-MM format.
+ * @param {string} ym - Current year-month string.
+ * @returns {string} Previous year-month string.
+ */
+function previousMonth(ym) {
+  const [y, m] = ym.split('-').map(Number);
+  const d = new Date(y, m - 1);
+  d.setMonth(d.getMonth() - 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+/**
+ * Insert or replace a monthly starting cash amount.
+ * If previous month exists, an expense record named '現金' is added
+ * using the formula: previous start + withdrawals - current start.
+ *
+ * @param {string} month - Year-month string in YYYY-MM format.
+ * @param {number} amount - Starting cash amount.
+ * @returns {void}
+ */
+export function insertCashStart(month, amount) {
+  const stmt = db.prepare('INSERT OR REPLACE INTO cash_starts (month, amount) VALUES (?, ?)');
+  stmt.run(month, amount);
+}
+
+/**
+ * Retrieve starting cash for a month.
+ * @param {string} month - Year-month string.
+ * @returns {{month:string, amount:number}|undefined} Start row.
+ */
+export function selectCashStart(month) {
+  return db.prepare('SELECT month, amount FROM cash_starts WHERE month = ?').get(month);
+}
+
+/**
+ * Insert a cash withdrawal record.
+ * @param {string} month - Year-month string.
+ * @param {number} amount - Withdrawal amount.
+ * @returns {number} Inserted row ID.
+ */
+export function insertCashWithdrawal(month, amount) {
+  const stmt = db.prepare('INSERT INTO cash_withdrawals (month, amount) VALUES (?, ?)');
+  const info = stmt.run(month, amount);
+  return Number(info.lastInsertRowid);
+}
+
+/**
+ * Retrieve withdrawals for a month.
+ * @param {string} month - Year-month string.
+ * @returns {Array<{id:number, month:string, amount:number, created_at:number}>} Rows.
+ */
+export function selectCashWithdrawals(month) {
+  return db.prepare('SELECT * FROM cash_withdrawals WHERE month = ? ORDER BY created_at').all(month);
+}
+

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,6 +1,7 @@
 import Dashboard from './components/Dashboard.js';
 import ExpenseForm from './components/ExpenseForm.js';
 import IncomeForm from './components/IncomeForm.js';
+import CashForm from './components/CashForm.js';
 
 /**
  * Application entry point. Renders components based on location hash.
@@ -18,6 +19,8 @@ async function render() {
     root.replaceChildren(ExpenseForm());
   } else if (hash === '#income') {
     root.replaceChildren(IncomeForm());
+  } else if (hash === '#cash') {
+    root.replaceChildren(CashForm());
   } else {
     root.replaceChildren(await Dashboard());
   }
@@ -25,4 +28,5 @@ async function render() {
 
 window.addEventListener('DOMContentLoaded', () => { render(); });
 window.addEventListener('hashchange', () => { render(); });
+
 

--- a/frontend/api/cashAPI.js
+++ b/frontend/api/cashAPI.js
@@ -1,0 +1,54 @@
+/**
+ * API helpers for cash management endpoints.
+ * @module cashAPI
+ */
+
+/**
+ * Fetch starting cash for a month.
+ * @param {number|string} year - Year component.
+ * @param {number|string} month - Month component.
+ * @returns {Promise<{month:string, amount:number}|{}>} Response JSON.
+ */
+export async function fetchCashStart(year, month) {
+  const res = await fetch(`/cash/start/${year}/${month}`);
+  return res.json();
+}
+
+/**
+ * Register starting cash.
+ * @param {string} month - Month string in YYYY-MM format.
+ * @param {number} amount - Amount value.
+ * @returns {Promise<Response>} Fetch response.
+ */
+export async function registerCashStartAPI(month, amount) {
+  return fetch('/cash/start', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ month, amount })
+  });
+}
+
+/**
+ * Fetch withdrawals for a month.
+ * @param {number|string} year - Year component.
+ * @param {number|string} month - Month component.
+ * @returns {Promise<object[]>} Array of withdrawal rows.
+ */
+export async function fetchWithdrawals(year, month) {
+  const res = await fetch(`/cash/withdraw/${year}/${month}`);
+  return res.json();
+}
+
+/**
+ * Register a new withdrawal.
+ * @param {string} month - Month string in YYYY-MM format.
+ * @param {number} amount - Withdrawal amount.
+ * @returns {Promise<Response>} Fetch response.
+ */
+export async function createWithdrawal(month, amount) {
+  return fetch('/cash/withdraw', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ month, amount })
+  });
+}

--- a/frontend/components/CashForm.js
+++ b/frontend/components/CashForm.js
@@ -1,0 +1,105 @@
+import NavBar from './NavBar.js';
+import { formatAmount } from '../utils/format.js';
+import {
+  fetchCashStart,
+  registerCashStartAPI,
+  fetchWithdrawals,
+  createWithdrawal
+} from '../api/cashAPI.js';
+
+/**
+ * Cash management page for tracking start amounts and withdrawals.
+ * @module CashForm
+ */
+export default function CashForm() {
+  const container = document.createElement('div');
+  container.className = 'min-h-screen flex flex-col items-center p-4 bg-gray-50';
+  container.appendChild(NavBar('現金管理'));
+
+  const now = new Date();
+  const monthInput = document.createElement('input');
+  monthInput.type = 'month';
+  monthInput.value = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2,'0')}`;
+  monthInput.className = 'border p-2 mb-4';
+  container.appendChild(monthInput);
+
+  const startForm = document.createElement('form');
+  startForm.className = 'flex flex-row space-x-2 w-full max-w-5xl mb-4';
+  const startInput = document.createElement('input');
+  startInput.type = 'number';
+  startInput.placeholder = '月初額';
+  startInput.className = 'border p-2 flex-1';
+  const startBtn = document.createElement('button');
+  startBtn.type = 'submit';
+  startBtn.textContent = '月初額登録';
+  startBtn.className = 'bg-blue-600 text-white p-2';
+  startForm.append(startInput, startBtn);
+  container.appendChild(startForm);
+
+  const withdrawForm = document.createElement('form');
+  withdrawForm.className = 'flex flex-row space-x-2 w-full max-w-5xl mb-4';
+  const withdrawInput = document.createElement('input');
+  withdrawInput.type = 'number';
+  withdrawInput.placeholder = '出金額';
+  withdrawInput.className = 'border p-2 flex-1';
+  const withdrawBtn = document.createElement('button');
+  withdrawBtn.type = 'submit';
+  withdrawBtn.textContent = '出金追加';
+  withdrawBtn.className = 'bg-blue-600 text-white p-2';
+  withdrawForm.append(withdrawInput, withdrawBtn);
+  container.appendChild(withdrawForm);
+
+  const listContainer = document.createElement('div');
+  listContainer.className = 'w-full max-w-5xl mt-4';
+  container.appendChild(listContainer);
+
+  const loadStart = async () => {
+    const [y, m] = monthInput.value.split('-');
+    const data = await fetchCashStart(y, m);
+    if (data && data.amount !== undefined) {
+      startInput.value = data.amount;
+    } else {
+      startInput.value = '';
+    }
+  };
+
+  const loadWithdrawals = async () => {
+    listContainer.innerHTML = '';
+    const [y, m] = monthInput.value.split('-');
+    const data = await fetchWithdrawals(y, m);
+    if (data.length === 0) {
+      listContainer.textContent = 'この月の出金記録はありません。';
+      return;
+    }
+    const ul = document.createElement('ul');
+    data.forEach(w => {
+      const li = document.createElement('li');
+      li.textContent = formatAmount(w.amount);
+      ul.appendChild(li);
+    });
+    listContainer.appendChild(ul);
+  };
+
+  monthInput.addEventListener('change', () => {
+    loadStart();
+    loadWithdrawals();
+  });
+
+  startForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    await registerCashStartAPI(monthInput.value, Number(startInput.value));
+  });
+
+  withdrawForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    await createWithdrawal(monthInput.value, Number(withdrawInput.value));
+    withdrawInput.value = '';
+    loadWithdrawals();
+  });
+
+  loadStart();
+  loadWithdrawals();
+
+  return container;
+}
+

--- a/frontend/components/NavBar.js
+++ b/frontend/components/NavBar.js
@@ -39,6 +39,13 @@ export default function NavBar(title) {
   incomeLink.className = 'text-blue-600 hover:underline';
   linkContainer.appendChild(incomeLink);
 
+  const cashLink = document.createElement('a');
+  cashLink.href = '#cash';
+  cashLink.textContent = '現金管理';
+  cashLink.className = 'text-blue-600 hover:underline';
+  linkContainer.appendChild(cashLink);
+
   nav.appendChild(linkContainer);
   return nav;
 }
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "家計簿アプリ開発",
   "main": "server.js",
   "scripts": {
-    "test": "node tests/data.test.js && node tests/db.test.js && node tests/expenseForm.test.js"
+    "test": "node tests/data.test.js && node tests/db.test.js && node tests/expenseForm.test.js && node tests/cash.test.js"
   },
   "keywords": [],
   "author": "",

--- a/server.js
+++ b/server.js
@@ -2,7 +2,23 @@ import http from 'http';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { addExpense, getExpenses, addIncome, getIncomes, getIncomesByMonth, updateIncome, updateExpense, deleteExpense, deleteIncome } from './db.js';
+import {
+  addExpense,
+  getExpenses,
+  addIncome,
+  getIncomes,
+  getIncomesByMonth,
+  updateIncome,
+  updateExpense,
+  deleteExpense,
+  deleteIncome
+} from './db.js';
+import {
+  registerCashStart,
+  getCashStart,
+  recordWithdrawal,
+  getWithdrawals
+} from './services/cashService.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -111,6 +127,51 @@ const server = http.createServer((req, res) => {
     deleteIncome(id);
     res.statusCode = 204;
     res.end();
+    return;
+  }
+
+  if (req.url.startsWith('/cash/start/') && req.method === 'GET') {
+    const parts = req.url.split('/');
+    const year = parts[3];
+    const month = parts[4];
+    const ym = `${year}-${String(month).padStart(2, '0')}`;
+    const data = getCashStart(ym) || {};
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(data));
+    return;
+  }
+
+  if (req.url === '/cash/start' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      const { month, amount } = JSON.parse(body || '{}');
+      registerCashStart(month, Number(amount));
+      res.statusCode = 201;
+      res.end('OK');
+    });
+    return;
+  }
+
+  if (req.url.startsWith('/cash/withdraw/') && req.method === 'GET') {
+    const parts = req.url.split('/');
+    const year = parts[3];
+    const month = parts[4];
+    const ym = `${year}-${String(month).padStart(2, '0')}`;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(getWithdrawals(ym)));
+    return;
+  }
+
+  if (req.url === '/cash/withdraw' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      const { month, amount } = JSON.parse(body || '{}');
+      recordWithdrawal(month, Number(amount));
+      res.statusCode = 201;
+      res.end('OK');
+    });
     return;
   }
 

--- a/services/cashService.js
+++ b/services/cashService.js
@@ -1,0 +1,75 @@
+/**
+ * Service layer for handling cash flow logic.
+ * @module services/cashService
+ */
+import {
+  addExpense,
+  insertCashStart,
+  selectCashStart,
+  insertCashWithdrawal,
+  selectCashWithdrawals
+} from '../db.js';
+
+/**
+ * Calculate the previous month string.
+ * @param {string} ym - Year-month string in YYYY-MM format.
+ * @returns {string} Previous month in YYYY-MM format.
+ */
+function previousMonth(ym) {
+  const [y, m] = ym.split('-').map(Number);
+  const d = new Date(y, m - 1);
+  d.setMonth(d.getMonth() - 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+/**
+ * Register a starting cash amount. Also records cash usage as an expense for the
+ * previous month if applicable.
+ *
+ * @param {string} month - Target month.
+ * @param {number} amount - Starting cash amount.
+ * @returns {void}
+ */
+export function registerCashStart(month, amount) {
+  insertCashStart(month, amount);
+
+  const prev = previousMonth(month);
+  const prevRow = selectCashStart(prev);
+  if (prevRow) {
+    const withdrawals = selectCashWithdrawals(prev);
+    const sum = withdrawals.reduce((s, w) => s + w.amount, 0);
+    const usage = prevRow.amount + sum - amount;
+    if (usage !== 0) {
+      addExpense(usage, '現金', prev);
+    }
+  }
+}
+
+/**
+ * Retrieve starting cash for a month.
+ * @param {string} month - Target month.
+ * @returns {{month:string, amount:number}|undefined} Row object.
+ */
+export function getCashStart(month) {
+  return selectCashStart(month);
+}
+
+/**
+ * Record a cash withdrawal.
+ * @param {string} month - Target month.
+ * @param {number} amount - Withdrawal amount.
+ * @returns {number} Inserted row id.
+ */
+export function recordWithdrawal(month, amount) {
+  return insertCashWithdrawal(month, amount);
+}
+
+/**
+ * Retrieve withdrawals for a month.
+ * @param {string} month - Target month.
+ * @returns {Array<{id:number, month:string, amount:number, created_at:number}>}
+ *   Array of rows.
+ */
+export function getWithdrawals(month) {
+  return selectCashWithdrawals(month);
+}

--- a/tests/cash.test.js
+++ b/tests/cash.test.js
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpFile = path.join(os.tmpdir(), `cash-${Date.now()}.sqlite`);
+process.env.DB_FILE = tmpFile;
+
+const dbModule = await import('../db.js');
+const cashService = await import('../services/cashService.js');
+
+// month start and withdrawal
+cashService.registerCashStart('2024-05', 100000);
+assert.strictEqual(cashService.getCashStart('2024-05').amount, 100000);
+
+cashService.recordWithdrawal('2024-05', 20000);
+assert.strictEqual(cashService.getWithdrawals('2024-05').length, 1);
+
+cashService.registerCashStart('2024-06', 80000);
+const cashExpense = dbModule.getExpenses().find(e => e.description === '現金' && e.target_month === '2024-05');
+assert.ok(cashExpense, 'cash expense should be added');
+assert.strictEqual(cashExpense.amount, 40000);
+
+fs.unlinkSync(tmpFile);
+console.log('Cash tests passed');
+


### PR DESCRIPTION
## Summary
- introduce cash flow tables in database and helper functions
- handle cash start and withdrawal routes in server
- provide CashForm UI and navigation link
- add unit tests for cash logic
- refactor cash flow logic into a service layer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872404b7cd4832a9072d905f3a2199e