### PR TITLE
Add recurring fixed expense items, endpoints, and Docker volume for SQLite

### DIFF
--- a/db.js
+++ b/db.js
@@ -20,7 +20,8 @@ CREATE TABLE IF NOT EXISTS expenses (
   amount INTEGER NOT NULL,
   description TEXT,
   target_month TEXT NOT NULL DEFAULT (strftime('%Y-%m','now')),
-  created_at INTEGER DEFAULT (strftime('%s','now'))
+  created_at INTEGER DEFAULT (strftime('%s','now')),
+  fixed_item_id INTEGER
 );
 CREATE TABLE IF NOT EXISTS incomes (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -37,6 +38,15 @@ CREATE TABLE IF NOT EXISTS cash_withdrawals (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   month TEXT NOT NULL,
   amount INTEGER NOT NULL,
+  created_at INTEGER DEFAULT (strftime('%s','now'))
+);
+CREATE TABLE IF NOT EXISTS fixed_expense_items (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  amount INTEGER NOT NULL,
+  description TEXT NOT NULL,
+  start_month TEXT NOT NULL,
+  end_month TEXT,
+  is_active INTEGER NOT NULL DEFAULT 1,
   created_at INTEGER DEFAULT (strftime('%s','now'))
 );
 `);
@@ -137,6 +147,66 @@ export function updateIncome(id, amount, description, targetMonth) {
 }
 
 /**
+ * Registers a fixed expense item.
+ * @param {number} amount - Fixed expense amount.
+ * @param {string} description - Fixed expense description.
+ * @param {string} startMonth - Application start month (YYYY-MM).
+ * @returns {number} Inserted fixed expense item ID.
+ */
+export function addFixedExpenseItem(amount, description, startMonth) {
+  const statement = db.prepare(
+    'INSERT INTO fixed_expense_items (amount, description, start_month) VALUES (?, ?, ?)'
+  );
+  const info = statement.run(amount, description, startMonth);
+  return Number(info.lastInsertRowid);
+}
+
+/**
+ * Ends application of a fixed expense item from the specified month.
+ * @param {number} id - Fixed expense item ID.
+ * @param {string} endMonth - End month (YYYY-MM).
+ * @returns {void}
+ */
+export function endFixedExpenseItem(id, endMonth) {
+  db.prepare('UPDATE fixed_expense_items SET end_month = ?, is_active = 0 WHERE id = ?').run(endMonth, id);
+}
+
+/**
+ * Applies active fixed expense items to the target month if not yet reflected.
+ * @param {string} targetMonth - Target month (YYYY-MM).
+ * @returns {number[]} Inserted expense IDs.
+ */
+export function applyFixedExpensesForMonth(targetMonth) {
+  const fixedItems = db.prepare(`
+    SELECT id, amount, description
+    FROM fixed_expense_items
+    WHERE start_month <= ?
+      AND (end_month IS NULL OR end_month > ?)
+      AND is_active = 1
+  `).all(targetMonth, targetMonth);
+  const insertedIds = [];
+  const findStatement = db.prepare(
+    'SELECT id FROM expenses WHERE target_month = ? AND fixed_item_id = ?'
+  );
+  const insertStatement = db.prepare(
+    'INSERT INTO expenses (amount, description, target_month, fixed_item_id) VALUES (?, ?, ?, ?)'
+  );
+  fixedItems.forEach((fixedItem) => {
+    const existing = findStatement.get(targetMonth, fixedItem.id);
+    if (!existing) {
+      const info = insertStatement.run(
+        fixedItem.amount,
+        fixedItem.description,
+        targetMonth,
+        fixedItem.id
+      );
+      insertedIds.push(Number(info.lastInsertRowid));
+    }
+  });
+  return insertedIds;
+}
+
+/**
  * Get previous month string for YYYY-MM format.
  * @param {string} ym - Current year-month string.
  * @returns {string} Previous year-month string.
@@ -191,4 +261,3 @@ export function insertCashWithdrawal(month, amount) {
 export function selectCashWithdrawals(month) {
   return db.prepare('SELECT * FROM cash_withdrawals WHERE month = ? ORDER BY created_at').all(month);
 }
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,10 @@ services:
     volumes:
       - .:/app
       - /app/node_modules
+      - sqlite_data:/data
     environment:
       - NODE_ENV=development
+      - DB_FILE=/data/data.sqlite
+
+volumes:
+  sqlite_data:

--- a/server.js
+++ b/server.js
@@ -11,7 +11,10 @@ import {
   updateIncome,
   updateExpense,
   deleteExpense,
-  deleteIncome
+  deleteIncome,
+  addFixedExpenseItem,
+  endFixedExpenseItem,
+  applyFixedExpensesForMonth
 } from './db.js';
 import {
   registerCashStart,
@@ -32,7 +35,12 @@ const frontendDir = path.join(__dirname, 'frontend');
 const port = process.env.PORT || 3000;
 
 const server = http.createServer((req, res) => {
-  if (req.url === '/expenses' && req.method === 'GET') {
+  const requestUrl = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+  if (requestUrl.pathname === '/expenses' && req.method === 'GET') {
+    const targetMonth = requestUrl.searchParams.get('month');
+    if (targetMonth) {
+      applyFixedExpensesForMonth(targetMonth);
+    }
     res.setHeader('Content-Type', 'application/json');
     res.end(JSON.stringify(getExpenses()));
     return;
@@ -127,6 +135,31 @@ const server = http.createServer((req, res) => {
     deleteIncome(id);
     res.statusCode = 204;
     res.end();
+    return;
+  }
+
+  if (requestUrl.pathname === '/fixed-expenses' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      const data = JSON.parse(body || '{}');
+      addFixedExpenseItem(Number(data.amount), data.description || '', data.startMonth);
+      res.statusCode = 201;
+      res.end('OK');
+    });
+    return;
+  }
+
+  if (requestUrl.pathname.startsWith('/fixed-expenses/') && req.method === 'PUT') {
+    const id = Number(requestUrl.pathname.split('/')[2]);
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      const data = JSON.parse(body || '{}');
+      endFixedExpenseItem(id, data.endMonth);
+      res.statusCode = 200;
+      res.end('OK');
+    });
     return;
   }
 

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -30,5 +30,18 @@ assert.strictEqual(incUpdated.amount, 2500, 'Income amount should be updated');
 dbModule.deleteIncome(incUpdated.id);
 assert.strictEqual(dbModule.getIncomes().length, 0, 'Income should be deleted');
 
+const fixedExpenseItemId = dbModule.addFixedExpenseItem(30000, '家賃', '2024-01');
+const insertedRowIds = dbModule.applyFixedExpensesForMonth('2024-03');
+assert.strictEqual(insertedRowIds.length, 1, 'A fixed expense should be applied once');
+const marchFixedExpenses = dbModule.getExpenses().filter((expense) => expense.target_month === '2024-03');
+assert.strictEqual(marchFixedExpenses.length, 1, 'A fixed expense should exist for the target month');
+
+const duplicatedInsertIds = dbModule.applyFixedExpensesForMonth('2024-03');
+assert.strictEqual(duplicatedInsertIds.length, 0, 'Fixed expense application should be idempotent');
+
+dbModule.endFixedExpenseItem(fixedExpenseItemId, '2024-04');
+const aprilInsertIds = dbModule.applyFixedExpensesForMonth('2024-04');
+assert.strictEqual(aprilInsertIds.length, 0, 'Ended fixed expense should not apply from the end month');
+
 fs.unlinkSync(tmpFile);
 console.log('SQLite tests passed');


### PR DESCRIPTION
### Motivation

- Support recurring fixed expenses that can be created once and applied to monthly expenses automatically.
- Prevent duplicate application of the same fixed expense to a month and allow stopping a fixed expense from a given month.
- Persist SQLite data when running in Docker by mounting a volume and pointing the app to a stable `DB_FILE` path.

### Description

- Added `fixed_expense_items` table and a `fixed_item_id` column on `expenses`, and adjusted schema defaults; created related DB utilities `addFixedExpenseItem`, `endFixedExpenseItem`, and `applyFixedExpensesForMonth` in `db.js`.
- Made `applyFixedExpensesForMonth` idempotent by checking existing `expenses` rows for the same `fixed_item_id` and `target_month` before inserting.
- Updated `server.js` to parse request URLs via `new URL(...)`, call `applyFixedExpensesForMonth` when `GET /expenses?month=YYYY-MM` is requested, and added HTTP handlers for `POST /fixed-expenses` and `PUT /fixed-expenses/:id` to create and end fixed expense items.
- Updated `docker-compose.yml` to add a named volume `sqlite_data` and set `DB_FILE=/data/data.sqlite` so the SQLite file is persisted between runs.
- Updated tests in `tests/db.test.js` to cover adding a fixed expense, applying it for a month, idempotency of application, and ending a fixed expense.

### Testing

- Ran the modified SQLite unit test script `tests/db.test.js`, which created a temporary DB, exercised expense/income operations and the new fixed-expense flows, and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13a63549a4832a8dc3ddc3daf73b13)